### PR TITLE
Fixed CWD when zipping themes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -236,7 +236,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {cwd: `./packages/${argv.theme}`}),
         zip(filename),
         dest(`packages/${argv.theme}/dist/`)
     ], handleError(done));


### PR DESCRIPTION
no issue

- the `src` command was zipping up files relative to the repo root so
  the zip contained the whole repo, which wasn't producing what we
  expected
- we can change the current working directory through an option and pass
  it the folder we want to zip up