### PR TITLE
update member flow logic

### DIFF
--- a/packages/edition/default.hbs
+++ b/packages/edition/default.hbs
@@ -49,10 +49,12 @@
                     </a>
                 {{/if}}
             </div>
-            {{#if @member}}
-                <button class="button-text menu-item members-account" data-portal="account">Account</button>
-            {{else}}
-                <button class="button-text menu-item members-login" data-portal="signin">Login</button>
+            {{#if @site.members_enabled}}
+                {{#if @member}}
+                    <button class="button-text menu-item members-account" data-portal="account">Account</button>
+                {{else}}
+                    <button class="button-text menu-item members-login" data-portal="signin">Login</button>
+                {{/if}}
             {{/if}}
         </div>
 

--- a/packages/edition/partials/cover.hbs
+++ b/packages/edition/partials/cover.hbs
@@ -14,17 +14,21 @@
             </div>
         {{/if}}
 
-        {{#unless @member}}
-            <form class="form-wrapper cover-form" data-members-form>
-                <input class="auth-email" type="email" data-members-email placeholder="Your email address" required="true" autocomplete="false">
+        {{#if @site.members_enabled}}
+            {{#unless @site.members_invite_only}}
+                {{#unless @member}}
+                    <form class="form-wrapper cover-form" data-members-form>
+                        <input class="auth-email" type="email" data-members-email placeholder="Your email address" required="true" autocomplete="false">
 
-                <button class="form-button" type="submit" aria-label="Submit">
-                    <span class="default">Subscribe</span>
-                    <span class="loader">{{> "icons/loader"}}</span>
-                    <span class="success">Email sent</span>
-                </button>
-            </form>
-        {{/unless}}
+                        <button class="form-button" type="submit" aria-label="Submit">
+                            <span class="default">Subscribe</span>
+                            <span class="loader">{{> "icons/loader"}}</span>
+                            <span class="success">Email sent</span>
+                        </button>
+                    </form>
+                {{/unless}}
+            {{/unless}}
+        {{/if}}
     </div>
 
     <button class="button-icon cover-arrow">


### PR DESCRIPTION
I made two changes here:

1. On Edition, the sign up form is present even when members are disabled in the admin. I wrapped the form in a conditional block that checks for `@site.members_enabled`. A wrinkle here is that someone who has the site in invite-only mode also won't want this shown, so I also added a conditional for `@site.members_invite_only`
2. The login button also appears when members are disabled. I check for `@site.members_enabled` and then enable/disable accordingly.

Ref #154 There is also a discussion about Journal, which I'll also take a look at. 

```handlebars
{{#if @site.description}}
            <div class="cover-description">
                {{#if @custom.email_signup_text}}
                    {{@custom.email_signup_text}}
                {{else}}
                    {{@site.description}}
                {{/if}}
            </div>
 {{/if}}
```

This code is also included. Here, the custom email signup text could still be shown, even when members are disabled. We could also wrap this in a conditional, but I think the easier solution is to just to leave this custom field blank in the Admin.  

References this Forum post: https://forum.ghost.org/t/editon-theme-bug-on-home-page/32176