### PR TITLE
[Headline] Show multiple authors on post pages

### DIFF
--- a/packages/headline/assets/css/screen.css
+++ b/packages/headline/assets/css/screen.css
@@ -379,6 +379,7 @@ body:not(.home-template) .gh-topic-grid .gh-card {
 .gh-author-name {
     font-size: 1.8rem;
     letter-spacing: -0.01em;
+    margin-bottom: 20px;
 }
 
 .gh-article-meta {

--- a/packages/headline/partials/post-meta.hbs
+++ b/packages/headline/partials/post-meta.hbs
@@ -1,6 +1,6 @@
 {{#is "post"}}
     <aside class="gh-article-sidebar">
-        {{#primary_author}}
+        {{#foreach authors}}
             <figure class="gh-author-image">
                 {{#if profile_image}}
                     <img src="{{profile_image}}" alt="{{name}}">
@@ -12,7 +12,7 @@
             <h4 class="gh-author-name">
                 <a href="{{url}}">{{name}}</a>
             </h4>
-        {{/primary_author}}
+        {{/foreach}}
 
         <div class="gh-article-meta">
             <div class="gh-article-meta-inner">


### PR DESCRIPTION
This update simply uses a `foreach` loop on posts to display multiple authors. It additionally adds a margin to author names in the same fashion as author images.

This has personally been an issue on the newspaper website I maintain: https://amherststudent.com

Thank you for the great work, and I hope to see this fix included!

Please let me know if there are any adjustments I can make to this change.