### PR TITLE
Solo: Only show email signup if members are enabled

### DIFF
--- a/packages/solo/index.hbs
+++ b/packages/solo/index.hbs
@@ -32,12 +32,14 @@
                 {{#if @custom.secondary_header}}
                     <p class="gh-about-secondary">{{{@custom.secondary_header}}}</p>
                 {{/if}}
-                {{#unless @member}}
-                    <div class="gh-subscribe-input" data-portal>
-                        jamie@example.com
-                        <span class="gh-btn gh-primary-btn">Subscribe</span>
-                    </div>
-                {{/unless}}
+                {{#if @site.members_enabled}}
+                    {{#unless @member}}
+                        <div class="gh-subscribe-input" data-portal>
+                            jamie@example.com
+                            <span class="gh-btn gh-primary-btn">Subscribe</span>
+                        </div>
+                    {{/unless}}
+                {{/if}}
             </div>
         </div>
     </div>


### PR DESCRIPTION
When email subscriptions are disabled, I would expect the signup field on the home page to be hidden. This change uses the same conditional as what's used in [default.hbs](https://github.com/shelbyspees/ghost-themes/blob/757d42dc8734e1762f73c2758ec55d899cc5b243/packages/solo/default.hbs#L63).

Tested by editing it locally and uploading the zipped files to my WIP personal Ghost site:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/5217772/196786430-c0471139-c79f-4ea9-b742-622ccfc66a18.png">

Thanks for the great theme!