### PR TITLE
added optional chaining

### DIFF
--- a/packages/_shared/assets/js/lib/dropdown.js
+++ b/packages/_shared/assets/js/lib/dropdown.js
@@ -2,7 +2,7 @@ function dropdown() {
     const mediaQuery = window.matchMedia('(max-width: 991px)');
 
     const menu = document.querySelector('.gh-head-menu');
-    const nav = menu.querySelector('.nav');
+    const nav = menu?.querySelector('.nav');
     if (!nav) return;
 
     const logo = document.querySelector('.gh-head-logo');


### PR DESCRIPTION
When themes don't have `.gh-head-menu`, they'll throw an error because the element can't be found. Optional chaining returns `undefined` and aborts the function.

This fixes the issue in Dope.