### PR TITLE
[alto] Add light/dark toggle button to navbar

### DIFF
--- a/packages/alto/default.hbs
+++ b/packages/alto/default.hbs
@@ -48,6 +48,11 @@
             </nav>
 
             <div class="gh-head-actions">
+                <div class="toggle-track">
+                    <div class="toggle-moon">{{> "icons/moon"}}</div>
+                    <div class="toggle-sun">{{> "icons/sun"}}</div>
+                    <div class="toggle-thumb"></div>
+                </div>
                 {{#unless @site.members_enabled}}
                     {{^match @custom.navigation_layout "Stacked"}}
                         <button class="gh-search gh-icon-btn" data-ghost-search>{{> "icons/search"}}</button>


### PR DESCRIPTION
Add toggle button to navbar of Alto theme.
Toggle button toggles between light mode and dark mode.

Toggle button was removed in #187, probably in mistake.
This pull request will re-add the toggle button.
If it was removed for some reason, I apologize. In that case, this pull request will be closed.

**Screenshot**
![bandicam 2022-11-18 01-31-27-011](https://user-images.githubusercontent.com/6961187/202503023-2088fe34-540b-4eef-b3a4-992756dbbd94.jpg)
![bandicam 2022-11-18 01-31-28-784](https://user-images.githubusercontent.com/6961187/202503029-fad304af-9a66-4592-a46b-82c8bf56ac59.jpg)