### PR TITLE
fix posts not appearing on some tag pages

### DIFF
--- a/packages/bulletin/tag.hbs
+++ b/packages/bulletin/tag.hbs
@@ -17,7 +17,7 @@
         </section>
 
         <div class="gh-feed">
-            {{#get "posts" filter="primary_tag:{{slug}}" limit="all"}}
+            {{#get "posts" filter="tags:{{slug}}" limit="all"}}
                 {{#foreach posts}}
                     {{> loop}}
                 {{/foreach}}

--- a/packages/digest/tag.hbs
+++ b/packages/digest/tag.hbs
@@ -17,7 +17,7 @@
         </section>
 
         <div class="gh-feed">
-            {{#get "posts" filter="primary_tag:{{slug}}" limit="all"}}
+            {{#get "posts" filter="tags:{{slug}}" limit="all"}}
                 {{#foreach posts}}
                     {{> loop}}
                 {{/foreach}}


### PR DESCRIPTION
ref: https://secure.helpscout.net/conversation/2100000977/90450?folderId=2416822

On Digest, tag pages use the `primary-tag` filter property to get posts. However, tag collections are based on all tags, not just primary ones. Therefore, in cases where the tag and the primary tag are different, those posts won't appear on the page. If there are no posts with the primary tag, then no posts will show up.

See this page for an example: https://updates.orchard.group/tag/orchard-way/

The fix for this was to substitute the `primary-tag` filter property for `tags`. Now, any post with the tag in question will be fetched for `tag.hbs`.