### PR TITLE
add h1 to homepage

### DIFF
--- a/packages/headline/default.hbs
+++ b/packages/headline/default.hbs
@@ -17,7 +17,8 @@
         <div class="gh-head-inner gh-inner">
             <div class="gh-head-brand">
                 <div class="gh-head-brand-wrapper">
-                    <a class="gh-head-logo" href="{{@site.url}}">
+                    {{#is "home"}}<h1 class="gh-head-logo">{{/is}}
+                    <a {{^is "home"}}class="gh-head-logo"{{/is}} href="{{@site.url}}">
                         {{#if @site.logo}}
                             <img src="{{@site.logo}}" alt="{{@site.title}}">
                             {{#if @custom.white_publication_logo_for_transparent_header}}
@@ -27,6 +28,7 @@
                             {{@site.title}}
                         {{/if}}
                     </a>
+                    {{#is "home"}}</h1>{{/is}}
                 </div>
                 <button class="gh-search gh-icon-btn" data-ghost-search>{{> "icons/search"}}</button>
                 <button class="gh-burger"></button>


### PR DESCRIPTION
Headline doesn't use an H1 on the homepage, which isn't ideal for SEO, accessibility, and goes against general best practices.

This fix turns the site title into an `H1` on the homepage but reverts to an `a` elsewhere.

Ref: https://forum.ghost.org/t/headline-theme-h1-missing/35282