### PR TITLE
Fix package version selection code

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,7 +53,7 @@ function doCSS(path, done) {
 }
 
 function doJS(path, done) {
-    const version = oldPackages.includes(path) ? 'v1' : 'v2';
+    const version = oldPackages.includes(path.replace(/^.\//, '')) ? 'v1' : 'v2';
     pump([
         src([
             `packages/_shared/assets/js/${version}/lib/**/*.js`,


### PR DESCRIPTION
The `path` variable is prefixed with `./` but it is not present in the `oldPackages` list.

See this issue for more details: https://github.com/TryGhost/Themes/issues/207#issuecomment-1446545371