### PR TITLE
Update dropdown.js to fix error with menu disappearing on tablet

### DIFF
--- a/packages/_shared/assets/js/v1/lib/dropdown.js
+++ b/packages/_shared/assets/js/v1/lib/dropdown.js
@@ -24,7 +24,7 @@ function dropdown() {
                 submenuItems.unshift(nav.lastElementChild);
                 nav.lastElementChild.remove();
             } else {
-                return;
+                break;
             }
         }
 


### PR DESCRIPTION
The current code results in makeDropdown removing all navigation items but not adding the ... for some edge cases. (Programming error- should be break to exit the while, to return to exit the function.)  Full description here, including examples from Headline:
https://forum.ghost.org/t/headline-header-bug-with-wide-logo/39174

