### PR TITLE
chore(locale): Add en and de locales to headline theme

### DIFF
--- a/packages/headline/default.hbs
+++ b/packages/headline/default.hbs
@@ -53,13 +53,13 @@
                     <div class="gh-head-members">
                         {{#unless @member}}
                             {{#unless @site.members_invite_only}}
-                                <a class="gh-head-link" href="#/portal/signin" data-portal="signin">Sign in</a>
-                                <a class="gh-head-btn gh-btn gh-primary-btn" href="#/portal/signup" data-portal="signup">Subscribe</a>
+                                <a class="gh-head-link" href="#/portal/signin" data-portal="signin">{{t "Sign in"}}</a>
+                                <a class="gh-head-btn gh-btn gh-primary-btn" href="#/portal/signup" data-portal="signup">{{t "Subscribe"}}</a>
                             {{else}}
-                                <a class="gh-head-btn gh-btn gh-primary-btn" href="#/portal/signin" data-portal="signin">Sign in</a>
+                                <a class="gh-head-btn gh-btn gh-primary-btn" href="#/portal/signin" data-portal="signin">{{t "Sign in"}}</a>
                             {{/unless}}
                         {{else}}
-                            <a class="gh-head-btn gh-btn gh-primary-btn" href="#/portal/account" data-portal="account">Account</a>
+                            <a class="gh-head-btn gh-btn gh-primary-btn" href="#/portal/account" data-portal="account">{{t "Account"}}</a>
                         {{/unless}}
                     </div>
                 {{/unless}}
@@ -74,11 +74,11 @@
             {{#if @site.members_enabled}}
             {{#unless @member}}
                 <section class="gh-subscribe">
-                    <h3 class="gh-subscribe-title">Subscribe to {{@site.title}}</h3>
+                    <h3 class="gh-subscribe-title">{{t "Subscribe to" }} {{@site.title}}</h3>
                     {{#if @custom.email_signup_text}}
                         <div class="gh-subscribe-description">{{@custom.email_signup_text}}</div>
                     {{/if}}
-                    <button class="gh-subscribe-btn gh-btn" data-portal="signup">{{> "icons/email"}} Subscribe now</button>
+                    <button class="gh-subscribe-btn gh-btn" data-portal="signup">{{> "icons/email"}} {{t "Subscribe now"}}</button>
                 </section>
             {{/unless}}
             {{/if}}

--- a/packages/headline/home.hbs
+++ b/packages/headline/home.hbs
@@ -5,9 +5,9 @@
         <section class="gh-topic gh-topic-grid">
             <h2 class="gh-topic-name">
                 {{#match pagination.pages ">" 1}}
-                    <a href="{{@site.url}}/page/2">Latest</a>
+                    <a href="{{@site.url}}/page/2">{{t "Latest"}}</a>
                 {{else}}
-                    Latest
+                    {{t "Latest"}}
                 {{/match}}
             </h2>
 
@@ -19,7 +19,7 @@
 
             <footer class="gh-topic-footer">
                 {{#match pagination.pages ">" 1}}
-                    <a class="gh-topic-link" href="{{@site.url}}/page/2">Show more {{> "icons/arrow"}}</a>
+                    <a class="gh-topic-link" href="{{@site.url}}/page/2">{{t "Show more"}} {{> "icons/arrow"}}</a>
                 {{/match}}
             </footer>
         </section>

--- a/packages/headline/index.hbs
+++ b/packages/headline/index.hbs
@@ -4,7 +4,7 @@
     <div class="gh-inner">
 
         <section class="gh-pagehead">
-            <h1 class="gh-pagehead-title">Latest</h1>
+            <h1 class="gh-pagehead-title">{{t "Latest"}}</h1>
         </section>
 
         <div class="gh-topic gh-topic-grid">

--- a/packages/headline/locales/de.json
+++ b/packages/headline/locales/de.json
@@ -1,0 +1,20 @@
+{
+    "% min": "% Min",
+    "1 min": "1 Min",
+    "Account": "Konto",
+    "Close (Esc)": "Schließen (Esc)",
+    "Comments": "Kommentare",
+    "Latest": "Neustes",
+    "More": "Mehr",
+    "Next (arrow right)": "Weiter (Pfeil rechts)",
+    "Previous (arrow left)": "Zurück (Pfeil links)",
+    "Read next": "Weiterlesen",
+    "Share": "Teilen",
+    "Show more": "Mehr anzeigen",
+    "Sign in": "Anmelden",
+    "Subscribe now": "Jetzt abonnieren",
+    "Subscribe": "Abonnieren",
+    "Subscribe to": "Abonnieren von",
+    "Toggle fullscreen": "Vollbild umschalten",
+    "Zoom in/out": "Vergrößern/Verkleinern"
+}

--- a/packages/headline/locales/en.json
+++ b/packages/headline/locales/en.json
@@ -1,0 +1,20 @@
+{
+    "% min": "",
+    "1 min": "",
+    "Account": "",
+    "Close (Esc)": "",
+    "Comments": "",
+    "Latest": "",
+    "More": "",
+    "Next (arrow right)": "",
+    "Previous (arrow left)": "",
+    "Read next": "",
+    "Share": "",
+    "Show more": "",
+    "Sign in": "",
+    "Subscribe now": "",
+    "Subscribe to": "",
+    "Subscribe": "",
+    "Toggle fullscreen": "",
+    "Zoom in/out": ""
+}

--- a/packages/headline/partials/comments.hbs
+++ b/packages/headline/partials/comments.hbs
@@ -2,7 +2,7 @@
     {{#if comments}}
         <div class="gh-comments gh-read-next gh-canvas">
             <section class="gh-pagehead">
-                <h4 class="gh-pagehead-title">Comments ({{comment_count empty="0" singular="" plural=""}})</h3>
+                <h4 class="gh-pagehead-title">{{t "Comments"}} ({{comment_count empty="0" singular="" plural=""}})</h3>
             </section>
             {{comments title="" count=false}}
         </div>

--- a/packages/headline/partials/post-meta.hbs
+++ b/packages/headline/partials/post-meta.hbs
@@ -27,7 +27,7 @@
                 <time class="gh-article-date" datetime="{{date format="YYYY-MM-DD"}}">{{date}}</time>
                 {{#if reading_time}}
                     <span class="gh-article-meta-sep"></span>
-                    <span class="gh-article-length">{{reading_time minute="1 min" minutes="% min"}}</span>
+                    <span class="gh-article-length">{{reading_time minute=(t "1 min") minutes=(t "% min")}}</span>
                 {{/if}}
             </div>
         </div>

--- a/packages/headline/partials/pswp.hbs
+++ b/packages/headline/partials/pswp.hbs
@@ -12,10 +12,10 @@
             <div class="pswp__top-bar">
                 <div class="pswp__counter"></div>
 
-                <button class="pswp__button pswp__button--close" title="Close (Esc)"></button>
-                <button class="pswp__button pswp__button--share" title="Share"></button>
-                <button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
-                <button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
+                <button class="pswp__button pswp__button--close" title="{{t "Close (Esc)"}}"></button>
+                <button class="pswp__button pswp__button--share" title="{{t "Share"}}"></button>
+                <button class="pswp__button pswp__button--fs" title="{{t "Toggle fullscreen"}}"></button>
+                <button class="pswp__button pswp__button--zoom" title="{{t "Zoom in/out"}}"></button>
 
                 <div class="pswp__preloader">
                     <div class="pswp__preloader__icn">
@@ -30,8 +30,8 @@
                 <div class="pswp__share-tooltip"></div>
             </div>
 
-            <button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)"></button>
-            <button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)"></button>
+            <button class="pswp__button pswp__button--arrow--left" title="{{t "Previous (arrow left)"}}"></button>
+            <button class="pswp__button pswp__button--arrow--right" title="{{t "Next (arrow right)"}}"></button>
 
             <div class="pswp__caption">
                 <div class="pswp__caption__center"></div>

--- a/packages/headline/partials/related-posts.hbs
+++ b/packages/headline/partials/related-posts.hbs
@@ -3,7 +3,7 @@
         {{#if next}}
             <div class="gh-read-next gh-canvas">
                 <section class="gh-pagehead">
-                    <h4 class="gh-pagehead-title">Read next</h4>
+                    <h4 class="gh-pagehead-title">{{t "Read next"}}</h4>
                 </section>
 
                 <div class="gh-topic gh-topic-grid">

--- a/packages/headline/partials/topic-grid.hbs
+++ b/packages/headline/partials/topic-grid.hbs
@@ -12,6 +12,6 @@
     </div>
 
     <footer class="gh-topic-footer">
-        <a class="gh-topic-link" href="{{url}}">Show more {{> "icons/arrow"}}</a>
+        <a class="gh-topic-link" href="{{url}}">{{t "Show more"}} {{> "icons/arrow"}}</a>
     </footer>
 </section>

--- a/packages/headline/partials/topic-minimal.hbs
+++ b/packages/headline/partials/topic-minimal.hbs
@@ -3,7 +3,7 @@
         <h2 class="gh-topic-name">
             <a href="{{url}}">{{name}}</a>
         </h2>
-        <a class="gh-topic-link" href="{{url}}">More {{> "icons/arrow"}}</a>
+        <a class="gh-topic-link" href="{{url}}">{{t "More"}} {{> "icons/arrow"}}</a>
     </header>
 
     <div class="gh-topic-content">


### PR DESCRIPTION
I localized the headline theme for German based on this documentation: https://ghost.org/docs/themes/helpers/translate/#5-use-the-translation-helper