### PR TITLE
🔍️ (headline | mobile nav): add arial-label for burger icon

### DIFF
--- a/packages/headline/default.hbs
+++ b/packages/headline/default.hbs
@@ -31,7 +31,7 @@
                     {{#is "home"}}</h1>{{/is}}
                 </div>
                 <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-                <button class="gh-burger"></button>
+                <button class="gh-burger" aria-label="Mobile menu"></button>
             </div>
 
             <nav class="gh-head-menu">


### PR DESCRIPTION
The mobile nav with burger icon create SEO accessibility issue:
**Buttons do not have an accessible name**