### PR TITLE
Correct Alto and Dawn double-printing @site.logo <img> when @custom.white_logo_for_dark_mode is set

### DIFF
--- a/packages/alto/default.hbs
+++ b/packages/alto/default.hbs
@@ -19,9 +19,10 @@
                 <div class="gh-head-brand-wrapper">
                     <a class="gh-head-logo" href="{{@site.url}}">
                         {{#if @site.logo}}
-                            <img src="{{@site.logo}}" alt="{{@site.title}}">
                             {{#if @custom.white_logo_for_dark_mode}}
                                 <img src="{{img_url @custom.white_logo_for_dark_mode}}" alt="{{@site.title}}">
+                            {{else}}
+                                <img src="{{@site.logo}}" alt="{{@site.title}}">
                             {{/if}}
                         {{else}}
                             {{@site.title}}

--- a/packages/dawn/default.hbs
+++ b/packages/dawn/default.hbs
@@ -19,9 +19,10 @@
                 <div class="gh-head-brand-wrapper">
                     <a class="gh-head-logo" href="{{@site.url}}">
                         {{#if @site.logo}}
-                            <img src="{{@site.logo}}" alt="{{@site.title}}">
                             {{#if @custom.white_logo_for_dark_mode}}
                                 <img src="{{img_url @custom.white_logo_for_dark_mode}}" alt="{{@site.title}}">
+                            {{else}}
+                                <img src="{{@site.logo}}" alt="{{@site.title}}">
                             {{/if}}
                         {{else}}
                             {{@site.title}}


### PR DESCRIPTION
Cross-reference [Issue 371](https://github.com/TryGhost/Themes/issues/371)