### PR TITLE
Correct footer layout bug for sites with long copyrights

### DIFF
--- a/packages/headline/assets/css/screen.css
+++ b/packages/headline/assets/css/screen.css
@@ -690,6 +690,7 @@ body:not(.home-template) .gh-topic-grid .gh-card {
     margin-top: 32px;
     color: var(--color-secondary-text);
     letter-spacing: -0.006em;
+    text-wrap: wrap;
 }
 
 .gh-subscribe ~ .gh-copyright {


### PR DESCRIPTION
This PR fixes the Headline theme footer, where the copyright element does not wrap.  It's a problem particularly on mobile for sites with long titles or long custom text in the @custom.footer_text variable.  nowrap is being inherited from gh-foot, so we need to explicitly set wrap for the copyright element.