### PR TITLE
a11y: Add "Toggle Menu" aria-label to all themes

### DIFF
--- a/packages/_shared/partials/navbar.hbs
+++ b/packages/_shared/partials/navbar.hbs
@@ -16,7 +16,7 @@
                 </a>
             </div>
             <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-            <button class="gh-burger"></button>
+            <button class="gh-burger" aria-label="Toggle menu"></button>
         </div>
 
         <nav class="gh-head-menu">

--- a/packages/alto/default.hbs
+++ b/packages/alto/default.hbs
@@ -29,7 +29,7 @@
                     </a>
                 </div>
                 <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-                <button class="gh-burger"></button>
+                <button class="gh-burger" aria-label="Toggle menu"></button>
             </div>
 
             <nav class="gh-head-menu">

--- a/packages/bulletin/default.hbs
+++ b/packages/bulletin/default.hbs
@@ -30,7 +30,7 @@
                         </a>
                     </div>
                     <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-                    <button class="gh-burger"></button>
+                    <button class="gh-burger" aria-label="Toggle menu"></button>
                 </div>
 
                 <nav class="gh-head-menu">

--- a/packages/dawn/default.hbs
+++ b/packages/dawn/default.hbs
@@ -29,7 +29,7 @@
                     </a>
                 </div>
                 <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-                <button class="gh-burger"></button>
+                <button class="gh-burger" aria-label="Toggle menu"></button>
             </div>
 
             <nav class="gh-head-menu">

--- a/packages/digest/default.hbs
+++ b/packages/digest/default.hbs
@@ -26,7 +26,7 @@
                     </a>
                 </div>
                 <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-                <button class="gh-burger"></button>
+                <button class="gh-burger" aria-label="Toggle menu"></button>
             </div>
 
             <nav class="gh-head-menu">

--- a/packages/ease/default.hbs
+++ b/packages/ease/default.hbs
@@ -26,7 +26,7 @@
                     </a>
                 </div>
                 <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-                <button class="gh-burger"></button>
+                <button class="gh-burger" aria-label="Toggle menu"></button>
             </div>
 
             <nav class="gh-head-menu">

--- a/packages/edition/default.hbs
+++ b/packages/edition/default.hbs
@@ -27,7 +27,7 @@
                     </a>
                 </div>
                 <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-                <button class="gh-burger"></button>
+                <button class="gh-burger" aria-label="Toggle menu"></button>
             </div>
 
             <nav class="gh-head-menu">

--- a/packages/episode/partials/components/navbar.hbs
+++ b/packages/episode/partials/components/navbar.hbs
@@ -16,7 +16,7 @@
                 </a>
             </div>
             <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-            <button class="gh-burger"></button>
+            <button class="gh-burger" aria-label="Toggle menu"></button>
         </div>
 
         <nav class="gh-head-menu">

--- a/packages/headline/default.hbs
+++ b/packages/headline/default.hbs
@@ -31,7 +31,7 @@
                     {{#is "home"}}</h1>{{/is}}
                 </div>
                 <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-                <button class="gh-burger"></button>
+                <button class="gh-burger" aria-label="Toggle menu"></button>
             </div>
 
             <nav class="gh-head-menu">

--- a/packages/journal/default.hbs
+++ b/packages/journal/default.hbs
@@ -26,7 +26,7 @@
                     </a>
                 </div>
                 <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-                <button class="gh-burger"></button>
+                <button class="gh-burger" aria-label="Toggle menu"></button>
             </div>
 
             <nav class="gh-head-menu">

--- a/packages/london/default.hbs
+++ b/packages/london/default.hbs
@@ -34,7 +34,7 @@
                     </a>
                 </div>
                 <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-                <button class="gh-burger"></button>
+                <button class="gh-burger" aria-label="Toggle menu"></button>
             </div>
 
             <nav class="gh-head-menu">

--- a/packages/ruby/default.hbs
+++ b/packages/ruby/default.hbs
@@ -26,7 +26,7 @@
                     </a>
                 </div>
                 <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-                <button class="gh-burger"></button>
+                <button class="gh-burger" aria-label="Toggle menu"></button>
             </div>
 
             <nav class="gh-head-menu">

--- a/packages/solo/default.hbs
+++ b/packages/solo/default.hbs
@@ -52,7 +52,7 @@
                     </a>
                 </div>
                 <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-                <button class="gh-burger"></button>
+                <button class="gh-burger" aria-label="Toggle menu"></button>
             </div>
 
             <nav class="gh-head-menu">

--- a/packages/taste/partials/components/navbar.hbs
+++ b/packages/taste/partials/components/navbar.hbs
@@ -16,7 +16,7 @@
                 </a>
             </div>
             <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-            <button class="gh-burger"></button>
+            <button class="gh-burger" aria-label="Toggle menu"></button>
         </div>
 
         <nav class="gh-head-menu">

--- a/packages/wave/default.hbs
+++ b/packages/wave/default.hbs
@@ -31,7 +31,7 @@
                     </a>
                 </div>
                 <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
-                <button class="gh-burger"></button>
+                <button class="gh-burger" aria-label="Toggle menu"></button>
             </div>
 
             <nav class="gh-head-menu">


### PR DESCRIPTION
This is same fix that was applied exclusively the Edge theme in #183 ported to all themes.

It supercedes #370, which would have applied the same fix with different wording exclusively to the Headline theme.
