### PR TITLE
Compatibility fix for gulp-zip

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ const postcss = require('gulp-postcss');
 const concat = require('gulp-concat');
 const uglify = require('gulp-uglify');
 const beeper = require('beeper');
-const zip = require('gulp-zip');
+const zip = require('gulp-zip').default;
 
 // postcss plugins
 const easyimport = require('postcss-easy-import');

--- a/packages/alto/gulpfile.js
+++ b/packages/alto/gulpfile.js
@@ -9,7 +9,7 @@ const postcss = require('gulp-postcss');
 const concat = require('gulp-concat');
 const uglify = require('gulp-uglify');
 const beeper = require('beeper');
-const zip = require('gulp-zip');
+const zip = require('gulp-zip').default;
 
 // postcss plugins
 const easyimport = require('postcss-easy-import');

--- a/packages/bulletin/gulpfile.js
+++ b/packages/bulletin/gulpfile.js
@@ -9,7 +9,7 @@ const postcss = require('gulp-postcss');
 const concat = require('gulp-concat');
 const uglify = require('gulp-uglify');
 const beeper = require('beeper');
-const zip = require('gulp-zip');
+const zip = require('gulp-zip').default;
 
 // postcss plugins
 const easyimport = require('postcss-easy-import');

--- a/packages/dawn/gulpfile.js
+++ b/packages/dawn/gulpfile.js
@@ -9,7 +9,7 @@ const postcss = require('gulp-postcss');
 const concat = require('gulp-concat');
 const uglify = require('gulp-uglify');
 const beeper = require('beeper');
-const zip = require('gulp-zip');
+const zip = require('gulp-zip').default;
 
 // postcss plugins
 const easyimport = require('postcss-easy-import');

--- a/packages/digest/gulpfile.js
+++ b/packages/digest/gulpfile.js
@@ -9,7 +9,7 @@ const postcss = require('gulp-postcss');
 const concat = require('gulp-concat');
 const uglify = require('gulp-uglify');
 const beeper = require('beeper');
-const zip = require('gulp-zip');
+const zip = require('gulp-zip').default;
 
 // postcss plugins
 const easyimport = require('postcss-easy-import');

--- a/packages/edition/gulpfile.js
+++ b/packages/edition/gulpfile.js
@@ -9,7 +9,7 @@ const postcss = require('gulp-postcss');
 const concat = require('gulp-concat');
 const uglify = require('gulp-uglify');
 const beeper = require('beeper');
-const zip = require('gulp-zip');
+const zip = require('gulp-zip').default;
 
 // postcss plugins
 const easyimport = require('postcss-easy-import');

--- a/packages/headline/gulpfile.js
+++ b/packages/headline/gulpfile.js
@@ -9,7 +9,7 @@ const postcss = require('gulp-postcss');
 const concat = require('gulp-concat');
 const uglify = require('gulp-uglify');
 const beeper = require('beeper');
-const zip = require('gulp-zip');
+const zip = require('gulp-zip').default;
 
 // postcss plugins
 const easyimport = require('postcss-easy-import');

--- a/packages/journal/gulpfile.js
+++ b/packages/journal/gulpfile.js
@@ -9,7 +9,7 @@ const postcss = require('gulp-postcss');
 const concat = require('gulp-concat');
 const uglify = require('gulp-uglify');
 const beeper = require('beeper');
-const zip = require('gulp-zip');
+const zip = require('gulp-zip').default;
 
 // postcss plugins
 const easyimport = require('postcss-easy-import');

--- a/packages/london/gulpfile.js
+++ b/packages/london/gulpfile.js
@@ -9,7 +9,7 @@ const postcss = require('gulp-postcss');
 const concat = require('gulp-concat');
 const uglify = require('gulp-uglify');
 const beeper = require('beeper');
-const zip = require('gulp-zip');
+const zip = require('gulp-zip').default;
 
 // postcss plugins
 const easyimport = require('postcss-easy-import');

--- a/packages/ruby/gulpfile.js
+++ b/packages/ruby/gulpfile.js
@@ -9,7 +9,7 @@ const postcss = require('gulp-postcss');
 const concat = require('gulp-concat');
 const uglify = require('gulp-uglify');
 const beeper = require('beeper');
-const zip = require('gulp-zip');
+const zip = require('gulp-zip').default;
 
 // postcss plugins
 const easyimport = require('postcss-easy-import');

--- a/packages/solo/gulpfile.js
+++ b/packages/solo/gulpfile.js
@@ -9,7 +9,7 @@ const postcss = require('gulp-postcss');
 const concat = require('gulp-concat');
 const uglify = require('gulp-uglify');
 const beeper = require('beeper');
-const zip = require('gulp-zip');
+const zip = require('gulp-zip').default;
 
 // postcss plugins
 const easyimport = require('postcss-easy-import');

--- a/packages/taste/gulpfile.js
+++ b/packages/taste/gulpfile.js
@@ -9,7 +9,7 @@ const postcss = require('gulp-postcss');
 const concat = require('gulp-concat');
 const uglify = require('gulp-uglify');
 const beeper = require('beeper');
-const zip = require('gulp-zip');
+const zip = require('gulp-zip').default;
 
 // postcss plugins
 const easyimport = require('postcss-easy-import');

--- a/packages/wave/gulpfile.js
+++ b/packages/wave/gulpfile.js
@@ -9,7 +9,7 @@ const postcss = require('gulp-postcss');
 const concat = require('gulp-concat');
 const uglify = require('gulp-uglify');
 const beeper = require('beeper');
-const zip = require('gulp-zip');
+const zip = require('gulp-zip').default;
 
 // postcss plugins
 const easyimport = require('postcss-easy-import');


### PR DESCRIPTION
I was attempting to do some small CSS adjustments with the theme Solo to suit a blog I have better, however the Gulp `zip` task was not working and kept throwing the error `TypeError: zip is not a function`.

The reason this was not working appears to be that `gulp-zip` now appears to export an ES Module. This is a quick patch which fixes this on every theme which appears to be affected by this change.