### PR TITLE
fix: don't change text encoding on sources that may include binary files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -321,7 +321,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ], {cwd: `./packages/${argv.theme}`}),
+        ], {cwd: `./packages/${argv.theme}`, encoding: false}),
         zip(filename),
         dest(`packages/${argv.theme}/dist/`)
     ], handleError(done));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -325,7 +325,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ], {cwd: `./packages/${argv.theme}`}),
+        ], {cwd: `./packages/${argv.theme}`, encoding: false}),
         zip(filename),
         dest(`packages/${argv.theme}/dist/`)
     ], handleError(done));

--- a/packages/alto/gulpfile.js
+++ b/packages/alto/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/alto/gulpfile.js
+++ b/packages/alto/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/bulletin/gulpfile.js
+++ b/packages/bulletin/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/bulletin/gulpfile.js
+++ b/packages/bulletin/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/dawn/gulpfile.js
+++ b/packages/dawn/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/dawn/gulpfile.js
+++ b/packages/dawn/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/digest/gulpfile.js
+++ b/packages/digest/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/digest/gulpfile.js
+++ b/packages/digest/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/dope/gulpfile.js
+++ b/packages/dope/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/dope/gulpfile.js
+++ b/packages/dope/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/ease/gulpfile.js
+++ b/packages/ease/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/ease/gulpfile.js
+++ b/packages/ease/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/edge/gulpfile.js
+++ b/packages/edge/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/edge/gulpfile.js
+++ b/packages/edge/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/edition/gulpfile.js
+++ b/packages/edition/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/edition/gulpfile.js
+++ b/packages/edition/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/episode/gulpfile.js
+++ b/packages/episode/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/episode/gulpfile.js
+++ b/packages/episode/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/headline/gulpfile.js
+++ b/packages/headline/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/headline/gulpfile.js
+++ b/packages/headline/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/journal/gulpfile.js
+++ b/packages/journal/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/journal/gulpfile.js
+++ b/packages/journal/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/london/gulpfile.js
+++ b/packages/london/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/london/gulpfile.js
+++ b/packages/london/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/ruby/gulpfile.js
+++ b/packages/ruby/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/ruby/gulpfile.js
+++ b/packages/ruby/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/solo/gulpfile.js
+++ b/packages/solo/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/solo/gulpfile.js
+++ b/packages/solo/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/taste/gulpfile.js
+++ b/packages/taste/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/taste/gulpfile.js
+++ b/packages/taste/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/wave/gulpfile.js
+++ b/packages/wave/gulpfile.js
@@ -89,7 +89,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));

--- a/packages/wave/gulpfile.js
+++ b/packages/wave/gulpfile.js
@@ -93,7 +93,7 @@ function zipper(done) {
             '!pnpm-workspace.yaml',
             '!AGENTS.md',
             '!CLAUDE.md',
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));


### PR DESCRIPTION
fixes #502

i found the option in documentation here https://gulpjs.com/docs/en/api/src/#options

the output of text files seems binary-equivalent to before this change, tested with sha256sum on the Edge theme
the output of binary files different to before this change, but is now identical to their source form (and they arent corrupted as a result) :3

the fix here should probably be applied to every theme's `gulpfile.js` alongside the one in this monorepo - i'm not fully sure if that should be done through separate PRs to each theme's repository, or done in this one? if it's best done in this pr please let me know

i will not be reading the ai generated feedback, if they somehow give any useful information please could a sentient being let me know

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tweaks Gulp `src` options for the zip packaging tasks, affecting how files are read during archive creation. Main risk is unintended changes in the generated zip contents if any tooling relied on text decoding behavior.
> 
> **Overview**
> Ensures theme zip builds don’t corrupt binary assets by updating all `zipper` tasks to read sources as raw bytes (`encoding: false`) instead of applying text encoding.
> 
> This change is applied in the root `gulpfile.js` theme zipper (monorepo build) and across each theme’s `gulpfile.js`, so packaged `.zip` outputs should now preserve binary files exactly as they exist on disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30c47349497a8a4fa488acd6f44371c402b6402a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->