### PR TITLE
Add shared social links footer partial

### DIFF
--- a/packages/_shared/assets/css/v1/components/footer.css
+++ b/packages/_shared/assets/css/v1/components/footer.css
@@ -8,6 +8,7 @@
 .gh-foot-inner {
     display: grid;
     grid-template-columns: 1fr auto 1fr;
+    align-items: center;
     gap: 40px;
     font-size: 1.3rem;
 }
@@ -17,6 +18,27 @@
     flex-direction: column;
     gap: 24px;
     align-items: center;
+}
+
+.gh-foot-center {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+}
+
+.gh-social-links {
+    display: flex;
+    gap: 16px;
+}
+
+.gh-social-links a {
+    display: inline-flex;
+}
+
+.gh-social-links svg {
+    width: 16px;
+    height: 16px;
 }
 
 .gh-foot-menu .nav {

--- a/packages/_shared/assets/css/v2/components/footer.css
+++ b/packages/_shared/assets/css/v2/components/footer.css
@@ -33,3 +33,24 @@
     color: var(--color-secondary-text);
     text-decoration: underline;
 }
+
+.gh-foot-center {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+}
+
+.gh-social-links {
+    display: flex;
+    gap: 16px;
+}
+
+.gh-social-links a {
+    display: inline-flex;
+}
+
+.gh-social-links svg {
+    width: 16px;
+    height: 16px;
+}

--- a/packages/_shared/package.json
+++ b/packages/_shared/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@tryghost/shared-theme-assets",
     "description": "Shared theme assets for official Ghost themes",
-    "version": "2.7.1",
+    "version": "2.7.0",
     "license": "MIT",
     "author": {
         "name": "Ghost Foundation",

--- a/packages/_shared/package.json
+++ b/packages/_shared/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@tryghost/shared-theme-assets",
     "description": "Shared theme assets for official Ghost themes",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "license": "MIT",
     "author": {
         "name": "Ghost Foundation",

--- a/packages/_shared/partials/author-header.hbs
+++ b/packages/_shared/partials/author-header.hbs
@@ -28,7 +28,7 @@
                         <a href="{{website}}" target="_blank" rel="noopener">{{website}}</a>
                     {{/if}}
                     {{#if twitter}}
-                        <a href="{{social_url type="twitter"}}" target="_blank" rel="noopener">{{> "icons/twitter"}}</a>
+                        <a href="{{social_url type="twitter"}}" target="_blank" rel="noopener">{{> "icons/x"}}</a>
                     {{/if}}
                     {{#if facebook}}
                         <a href="{{social_url type="facebook"}}" target="_blank" rel="noopener">{{> "icons/facebook"}}</a>

--- a/packages/_shared/partials/footer.hbs
+++ b/packages/_shared/partials/footer.hbs
@@ -5,9 +5,21 @@
 
 <footer class="gh-foot gh-outer">
     <div class="gh-foot-inner gh-inner">
-        <nav class="gh-foot-menu">
-            {{navigation type="secondary"}}
-        </nav>
+        <div class="gh-foot-center">
+            <div class="gh-social-links">
+                {{#social_accounts @site}}
+                    <a href="{{href}}" target="_blank" rel="noopener" aria-label="{{name}}">
+                        {{#> (concat "icons/" type)}}
+                            {{!-- Fallback when no per-platform icon partial exists --}}
+                            <span>{{name}}</span>
+                        {{/undefined}}
+                    </a>
+                {{/social_accounts}}
+            </div>
+            <nav class="gh-foot-menu">
+                {{navigation type="secondary"}}
+            </nav>
+        </div>
 
         <div class="gh-copyright">
             {{#unless footerText}}


### PR DESCRIPTION
## Summary
- add shared footer social link markup and styles
- switch shared author Twitter icon usage to X
- bump shared theme assets package version to 2.7.1

## Testing
- git diff --cached --check
- node -e Handlebars parse for changed shared partials

Note: this intentionally excludes theme built assets and locale output; those belong in the follow-up theme consumer PR.