### PR TITLE
Moved Renovate config into renovate.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,5 @@
     },
     "browserslist": [
         "defaults"
-    ],
-    "renovate": {
-        "extends": [
-            "@tryghost:theme"
-        ],
-        "ignoreDeps": ["gulp-zip"]
-    }
+    ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "@tryghost:theme",
+        "github>TryGhost/Themes//packages/theme-translations/renovate-config"
+    ],
+    "ignoreDeps": [
+        "gulp-zip"
+    ]
+}


### PR DESCRIPTION
## Summary

- Moved the repository Renovate settings out of `package.json` and into root `renovate.json`
- Added the Renovate schema reference
- Extended the root config from the theme translations organization preset

## Testing

- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); JSON.parse(require('fs').readFileSync('renovate.json','utf8')); console.log('JSON OK')"`