### PR TITLE
Updated Themes Renovate preset

### DIFF
--- a/packages/theme-translations/README.md
+++ b/packages/theme-translations/README.md
@@ -154,15 +154,17 @@ Blank values (`""`) in override files are ignored, so you won't accidentally cle
 
 ## Renovate auto-merge
 
-To automatically merge translation updates, extend the shipped Renovate preset in your theme's `renovate.json`:
+Official Ghost theme repositories should extend the shared theme preset in `TryGhost/renovate-config`. This includes the translation auto-merge rule:
 
 ```json
 {
-    "extends": ["github>TryGhost/Themes:packages/theme-translations/renovate-config"]
+    "extends": ["local>TryGhost/renovate-config:theme.json5"]
 }
 ```
 
-This auto-merges `@tryghost/theme-translations` version bumps on weekdays via PR (so CI still runs).
+This auto-merges `@tryghost/theme-translations` version bumps on weekdays via PR (so CI still runs). The package-local `renovate-config.json` is available for repos that only need the translation update rule without the full Ghost theme preset.
+
+TODO: remove the package-local `renovate-config.json` once all themes that extend it directly have migrated to the shared theme preset.
 
 ## Package development
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "@tryghost:theme",
-        "github>TryGhost/Themes//packages/theme-translations/renovate-config"
+        "local>TryGhost/renovate-config:theme.json5"
     ],
     "ignoreDeps": [
         "gulp-zip"


### PR DESCRIPTION
## Summary
- Moved `renovate.json` from the deprecated `@tryghost:theme` npm/slimer preset to `local>TryGhost/renovate-config:theme.json5`
- Removed the separate theme-translations preset extender because the shared theme preset now centralizes that rule
- Updated the theme-translations README to document the shared preset and the future removal of the package-local translation-only preset

## Testing
- `RENOVATE_CONFIG_FILE=renovate.json npx -p renovate renovate-config-validator`
- `git diff --check`