### PR TITLE
Add theme CI gates and subtree workflow docs

### DIFF
--- a/.github/workflows/alto.yml
+++ b/.github/workflows/alto.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/alto/**'
       - '.github/workflows/alto.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme alto
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/bulletin.yml
+++ b/.github/workflows/bulletin.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/bulletin/**'
       - '.github/workflows/bulletin.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme bulletin
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/dawn.yml
+++ b/.github/workflows/dawn.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/dawn/**'
       - '.github/workflows/dawn.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme dawn
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/digest/**'
       - '.github/workflows/digest.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme digest
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/dope.yml
+++ b/.github/workflows/dope.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/dope/**'
       - '.github/workflows/dope.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme dope
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/ease.yml
+++ b/.github/workflows/ease.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/ease/**'
       - '.github/workflows/ease.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme ease
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/edge/**'
       - '.github/workflows/edge.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme edge
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/edition.yml
+++ b/.github/workflows/edition.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/edition/**'
       - '.github/workflows/edition.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme edition
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/episode.yml
+++ b/.github/workflows/episode.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/episode/**'
       - '.github/workflows/episode.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme episode
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/headline.yml
+++ b/.github/workflows/headline.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/headline/**'
       - '.github/workflows/headline.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme headline
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/journal.yml
+++ b/.github/workflows/journal.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/journal/**'
       - '.github/workflows/journal.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme journal
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/london.yml
+++ b/.github/workflows/london.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/london/**'
       - '.github/workflows/london.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme london
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/ruby/**'
       - '.github/workflows/ruby.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme ruby
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/solo.yml
+++ b/.github/workflows/solo.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/solo/**'
       - '.github/workflows/solo.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme solo
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/taste.yml
+++ b/.github/workflows/taste.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/taste/**'
       - '.github/workflows/taste.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme taste
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/wave.yml
+++ b/.github/workflows/wave.yml
@@ -9,6 +9,9 @@ on:
       - 'packages/wave/**'
       - '.github/workflows/wave.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -24,6 +27,16 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme wave
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ This monorepo contains three types of packages, each with a different shipping m
 
 Each theme has its own CI workflow (`.github/workflows/<theme>.yml`). On push to `main`, the workflow runs tests, deploys the theme to its Ghost demo site via `action-deploy-theme`, and pushes to its standalone subtree repo (e.g. `TryGhost/Taste`). Themes are marked `"private": true` and are not published to npm.
 
+See [docs/architecture.md](docs/architecture.md) for the package, deploy, and subtree sync flow.
+
 ### `@tryghost/shared-theme-assets` (`packages/_shared/`)
 
 Shared CSS, JS, and Handlebars partials used by all themes. Published to npm so themes can pin a version via `devDependencies`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,28 @@
+# Themes Architecture
+
+The `TryGhost/Themes` repository is the source of truth for official theme package content. Each package under `packages/<theme>/` is a complete Ghost theme that is tested and shipped from this monorepo, then mirrored to its standalone `TryGhost/<Theme>` repository by CI.
+
+## Subtree workflow
+
+Package changes should be made in `packages/<theme>/`. The per-theme workflow tests that package, deploys it to the matching demo site, and force-pushes the package directory to the standalone mirror repository. Repo-level settings on the standalone mirror, such as descriptions and branch rulesets, are managed on the mirror repository itself.
+
+```mermaid
+flowchart TD
+    PR["Pull request changes packages/<theme>"] --> Test["Run pnpm test:ci --theme <theme>"]
+    Test --> Gate["All tests pass"]
+    Gate --> Merge["Merge to main"]
+    Merge --> Deploy["Deploy package to theme demo site"]
+    Merge --> Subtree["Push packages/<theme> to TryGhost/<Theme>"]
+    Subtree --> Mirror["Standalone mirror repository"]
+```
+
+## Package boundaries
+
+- Source CSS, JavaScript, templates, partials, locales, and package metadata belong inside the relevant `packages/<theme>/` directory.
+- Shared CSS, JavaScript, and partials belong in `packages/_shared/` and are published as `@tryghost/shared-theme-assets`.
+- Shared translations belong in `packages/theme-translations/` and are published as `@tryghost/theme-translations`.
+- Standalone mirror repositories receive package content from subtree sync; direct content edits there can be overwritten by the next sync.
+
+## CI boundaries
+
+Per-theme workflows live at `.github/workflows/<theme>.yml`. Each workflow scopes validation by passing the package name to `pnpm test:ci --theme <theme>`, then performs deploy and subtree work after merge. Do not add separate package-local workflow files for monorepo packages; the root workflows are the source of truth.

--- a/packages/alto/AGENTS.md
+++ b/packages/alto/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the Alto Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/alto` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme alto
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/alto/CLAUDE.md
+++ b/packages/alto/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/bulletin/AGENTS.md
+++ b/packages/bulletin/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the Bulletin Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/bulletin` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme bulletin
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/bulletin/CLAUDE.md
+++ b/packages/bulletin/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/dawn/AGENTS.md
+++ b/packages/dawn/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the Dawn Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/dawn` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme dawn
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/dawn/CLAUDE.md
+++ b/packages/dawn/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/digest/AGENTS.md
+++ b/packages/digest/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the Digest Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/digest` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme digest
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/digest/CLAUDE.md
+++ b/packages/digest/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/dope/AGENTS.md
+++ b/packages/dope/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the Dope Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/dope` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme dope
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/dope/CLAUDE.md
+++ b/packages/dope/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/ease/AGENTS.md
+++ b/packages/ease/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the Ease Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/ease` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme ease
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/ease/CLAUDE.md
+++ b/packages/ease/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/edge/AGENTS.md
+++ b/packages/edge/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the Edge Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/edge` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme edge
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/edge/CLAUDE.md
+++ b/packages/edge/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/edition/AGENTS.md
+++ b/packages/edition/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the Edition Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/edition` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme edition
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/edition/CLAUDE.md
+++ b/packages/edition/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/episode/AGENTS.md
+++ b/packages/episode/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the Episode Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/episode` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme episode
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/episode/CLAUDE.md
+++ b/packages/episode/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/episode/README.md
+++ b/packages/episode/README.md
@@ -1,0 +1,42 @@
+# Episode
+
+Episode is a [Ghost](https://github.com/TryGhost/Ghost) theme dedicated to podcasters. Share your voice and words with your audience.
+
+**Demo: https://episode.ghost.io**
+
+# Instructions
+
+1. [Download this theme](https://github.com/TryGhost/Episode/archive/main.zip)
+2. Log into Ghost, and go to the `Design` settings area to upload the zip file
+
+# Development
+
+Styles are compiled using Gulp/PostCSS to polyfill future CSS spec. You'll need [Node](https://nodejs.org/), [pnpm](https://pnpm.io/) and [Gulp](https://gulpjs.com) installed globally. After that, from the theme's root directory:
+
+```bash
+# Install
+pnpm install
+
+# Run build & watch for changes
+pnpm dev
+```
+
+Now you can edit `/assets/css/` files, which will be compiled to `/assets/built/` automatically.
+
+The `zip` Gulp task packages the theme files into `dist/episode.zip`, which you can then upload to your site.
+
+```bash
+pnpm zip
+```
+
+# Contribution
+
+This repo is synced automatically with [TryGhost/Themes](https://github.com/TryGhost/Themes) monorepo. If you're looking to contribute or raise an issue, head over to the main repository [TryGhost/Themes](https://github.com/TryGhost/Themes) where our official themes are developed.
+
+### Theme translations
+
+Please see the @Tryghost/Themes/theme-translations/README.md for how to edit or contribute translations.
+
+# Copyright & License
+
+Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](LICENSE).

--- a/packages/headline/AGENTS.md
+++ b/packages/headline/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the Headline Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/headline` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme headline
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/headline/CLAUDE.md
+++ b/packages/headline/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/journal/AGENTS.md
+++ b/packages/journal/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the Journal Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/journal` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme journal
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/journal/CLAUDE.md
+++ b/packages/journal/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/london/AGENTS.md
+++ b/packages/london/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the London Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/london` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme london
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/london/CLAUDE.md
+++ b/packages/london/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/ruby/AGENTS.md
+++ b/packages/ruby/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the Ruby Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/ruby` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme ruby
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/ruby/CLAUDE.md
+++ b/packages/ruby/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/solo/AGENTS.md
+++ b/packages/solo/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the Solo Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/solo` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme solo
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/solo/CLAUDE.md
+++ b/packages/solo/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/taste/AGENTS.md
+++ b/packages/taste/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the Taste Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/taste` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme taste
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/taste/CLAUDE.md
+++ b/packages/taste/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/taste/README.md
+++ b/packages/taste/README.md
@@ -1,0 +1,42 @@
+# Taste
+
+Taste is a recipe-focused [Ghost](https://github.com/TryGhost/Ghost) theme for food publishers who want magazine-style sections, email signup prompts, and configurable homepage topics.
+
+**Demo: https://taste.ghost.io**
+
+# Instructions
+
+1. [Download this theme](https://github.com/TryGhost/Taste/archive/main.zip)
+2. Log into Ghost, and go to the `Design` settings area to upload the zip file
+
+# Development
+
+Styles are compiled using Gulp/PostCSS to polyfill future CSS spec. You'll need [Node](https://nodejs.org/), [pnpm](https://pnpm.io/) and [Gulp](https://gulpjs.com) installed globally. After that, from the theme's root directory:
+
+```bash
+# Install
+pnpm install
+
+# Run build & watch for changes
+pnpm dev
+```
+
+Now you can edit `/assets/css/` or `/assets/js/` files, which will be compiled to `/assets/built/` automatically.
+
+The `zip` Gulp task packages the theme files into `dist/taste.zip`, which you can then upload to your site.
+
+```bash
+pnpm zip
+```
+
+# Contribution
+
+This repo is synced automatically with the [TryGhost/Themes](https://github.com/TryGhost/Themes) monorepo. If you're looking to contribute or raise an issue, head over to the main repository where our official themes are developed.
+
+## Theme translations
+
+Please see the @Tryghost/Themes/theme-translations/README.md for how to edit or contribute translations.
+
+# Copyright & License
+
+Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](LICENSE).

--- a/packages/wave/AGENTS.md
+++ b/packages/wave/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Scope
+
+This package is the Wave Ghost theme. In the standalone mirror repository, this tree is pushed from `TryGhost/Themes/packages/wave` by subtree sync; make durable theme-content changes in `TryGhost/Themes` unless the task is explicitly repo-level metadata or GitHub settings.
+
+## Commands
+
+Use pnpm, pinned by `package.json`.
+
+```bash
+pnpm install
+pnpm dev
+pnpm test
+pnpm zip
+```
+
+From the `TryGhost/Themes` monorepo root, validate this package with:
+
+```bash
+pnpm test:ci --theme wave
+```
+
+## Boundaries
+
+- Edit source CSS in `assets/css/`, source JavaScript in `assets/js/`, and templates/partials as `.hbs` files.
+- Keep generated `assets/built/` files in sync when source assets change.
+- Do not commit `node_modules/`, secrets, or local Ghost content.
+- Translation changes normally belong in `TryGhost/Themes/packages/theme-translations`; package-local locale overrides should be intentional and rebuilt.

--- a/packages/wave/CLAUDE.md
+++ b/packages/wave/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- add stable `All tests pass` gates to the existing per-theme monorepo workflows
- add package-level `AGENTS.md` files and `CLAUDE.md` symlinks that survive subtree sync
- add missing README files for Episode and Taste
- document the package, deploy, and subtree sync flow in docs/architecture.md

## Validation
- ruby YAML parse over root workflow files
- verified no `packages/*/.github/workflows/test.yml` files remain
- package `CLAUDE.md` symlink check
- pnpm test:ci --theme alto
