### PR TITLE
Exclude agent docs from theme zips

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -322,7 +322,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ], {cwd: `./packages/${argv.theme}`}),
         zip(filename),
         dest(`packages/${argv.theme}/dist/`)

--- a/packages/alto/gulpfile.js
+++ b/packages/alto/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')

--- a/packages/bulletin/gulpfile.js
+++ b/packages/bulletin/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')

--- a/packages/dawn/gulpfile.js
+++ b/packages/dawn/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')

--- a/packages/digest/gulpfile.js
+++ b/packages/digest/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')

--- a/packages/dope/gulpfile.js
+++ b/packages/dope/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')

--- a/packages/ease/gulpfile.js
+++ b/packages/ease/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')

--- a/packages/edge/gulpfile.js
+++ b/packages/edge/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')

--- a/packages/edition/gulpfile.js
+++ b/packages/edition/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')

--- a/packages/episode/gulpfile.js
+++ b/packages/episode/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')

--- a/packages/headline/gulpfile.js
+++ b/packages/headline/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')

--- a/packages/journal/gulpfile.js
+++ b/packages/journal/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')

--- a/packages/london/gulpfile.js
+++ b/packages/london/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')

--- a/packages/ruby/gulpfile.js
+++ b/packages/ruby/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')

--- a/packages/solo/gulpfile.js
+++ b/packages/solo/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')

--- a/packages/taste/gulpfile.js
+++ b/packages/taste/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')

--- a/packages/wave/gulpfile.js
+++ b/packages/wave/gulpfile.js
@@ -90,7 +90,9 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ]),
         zip(filename),
         dest('dist/')


### PR DESCRIPTION
## Summary
- Excludes `AGENTS.md` and `CLAUDE.md` from the root monorepo zip task.
- Applies the same exclusions to each package-local theme zipper so subtree mirrors inherit the packaging fix.

closes #542

## Validation
- `pnpm exec gulp zip --theme <theme>` for all 16 themes, with each generated archive inspected for `AGENTS.md` / `CLAUDE.md`.
- `pnpm --dir packages/alto zip`, with the generated archive inspected for `AGENTS.md` / `CLAUDE.md`.
