### PR TITLE
Added archive export ignores for theme packages

### DIFF
--- a/packages/alto/.gitattributes
+++ b/packages/alto/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore

--- a/packages/bulletin/.gitattributes
+++ b/packages/bulletin/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore

--- a/packages/dawn/.gitattributes
+++ b/packages/dawn/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore

--- a/packages/digest/.gitattributes
+++ b/packages/digest/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore

--- a/packages/dope/.gitattributes
+++ b/packages/dope/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore

--- a/packages/ease/.gitattributes
+++ b/packages/ease/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore

--- a/packages/edge/.gitattributes
+++ b/packages/edge/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore

--- a/packages/edition/.gitattributes
+++ b/packages/edition/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore

--- a/packages/episode/.gitattributes
+++ b/packages/episode/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore

--- a/packages/headline/.gitattributes
+++ b/packages/headline/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore

--- a/packages/journal/.gitattributes
+++ b/packages/journal/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore

--- a/packages/london/.gitattributes
+++ b/packages/london/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore

--- a/packages/ruby/.gitattributes
+++ b/packages/ruby/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore

--- a/packages/solo/.gitattributes
+++ b/packages/solo/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore

--- a/packages/taste/.gitattributes
+++ b/packages/taste/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore

--- a/packages/wave/.gitattributes
+++ b/packages/wave/.gitattributes
@@ -1,0 +1,4 @@
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/pnpm-workspace.yaml export-ignore
+/.gitattributes export-ignore


### PR DESCRIPTION
## Summary

- adds package-level `.gitattributes` files to all subtree-published themes
- excludes `AGENTS.md`, `CLAUDE.md`, `pnpm-workspace.yaml`, and `.gitattributes` from GitHub-generated source archives
- keeps the files tracked in the monorepo and standalone theme source checkouts

## Why

The standalone theme README download links use GitHub source archives such as `archive/main.zip`. Those archives are generated from the repository contents, not from the theme Gulp zipper, so repo-management files need `export-ignore` rules at the standalone repo root after subtree sync.

## Validation

- `git check-attr export-ignore` reports `set` for all target files across all 16 theme packages
- simulated a Solo `git archive` and confirmed the target files are omitted
