### PR TITLE
Standardize theme CI gate on the Required checks pass aggregator check

### DIFF
--- a/.github/workflows/alto.yml
+++ b/.github/workflows/alto.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme alto
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/bulletin.yml
+++ b/.github/workflows/bulletin.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme bulletin
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/dawn.yml
+++ b/.github/workflows/dawn.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme dawn
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/digest.yml
+++ b/.github/workflows/digest.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme digest
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/dope.yml
+++ b/.github/workflows/dope.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme dope
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/ease.yml
+++ b/.github/workflows/ease.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme ease
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme edge
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/edition.yml
+++ b/.github/workflows/edition.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme edition
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/episode.yml
+++ b/.github/workflows/episode.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme episode
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/headline.yml
+++ b/.github/workflows/headline.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme headline
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/journal.yml
+++ b/.github/workflows/journal.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme journal
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/london.yml
+++ b/.github/workflows/london.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme london
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme ruby
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/solo.yml
+++ b/.github/workflows/solo.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme solo
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/taste.yml
+++ b/.github/workflows/taste.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme taste
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/wave.yml
+++ b/.github/workflows/wave.yml
@@ -27,8 +27,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci --theme wave
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/alto/.github/workflows/test.yml
+++ b/packages/alto/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/bulletin/.github/workflows/test.yml
+++ b/packages/bulletin/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/dawn/.github/workflows/test.yml
+++ b/packages/dawn/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/digest/.github/workflows/test.yml
+++ b/packages/digest/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/dope/.github/workflows/test.yml
+++ b/packages/dope/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/ease/.github/workflows/test.yml
+++ b/packages/ease/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/edge/.github/workflows/test.yml
+++ b/packages/edge/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/edition/.github/workflows/test.yml
+++ b/packages/edition/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/episode/.github/workflows/test.yml
+++ b/packages/episode/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/headline/.github/workflows/test.yml
+++ b/packages/headline/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/journal/.github/workflows/test.yml
+++ b/packages/journal/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/london/.github/workflows/test.yml
+++ b/packages/london/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/ruby/.github/workflows/test.yml
+++ b/packages/ruby/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/solo/.github/workflows/test.yml
+++ b/packages/solo/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/taste/.github/workflows/test.yml
+++ b/packages/taste/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/wave/.github/workflows/test.yml
+++ b/packages/wave/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run: pnpm exec gscan --fatal --verbose .
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

The org is standardizing every repo's branch protection on one stable required status check, `Required checks pass`, instead of coupling protection to individual CI job names. The 16 theme repos (alto, bulletin, dawn, digest, dope, ease, edge, edition, episode, headline, journal, london, ruby, solo, taste, wave) are **git-subtree force-push mirrors** of this monorepo, so their CI gate is defined here — not in the downstream repos.

Each theme has the gate in two files:
- `.github/workflows/<theme>.yml` — gates this monorepo's PRs
- `packages/<theme>/.github/workflows/test.yml` — force-pushed downstream to `TryGhost/<Theme>`, where the ruleset requires the check

The downstream mirror rulesets have already been pointed at `Required checks pass`. Editing the mirror repos directly doesn't stick (the next subtree publish overwrites them), so this monorepo change is what actually migrates them once it merges and republishes.

## What

Renames the gate job `all-tests-pass` / `All tests pass` → `required-checks-pass` / `Required checks pass` across all 32 workflow files. Pure rename — nothing `needs` the gate job, and its `always()` + failure/cancelled semantics are unchanged.

## Ordering note

Until this merges and the subtree job republishes, each mirror's ruleset requires `Required checks pass` while its published `test.yml` still emits `All tests pass`. That only affects direct PRs opened against a mirror repo (rare; dev happens here), and Ghost Foundation retains ruleset bypass. Merging this closes that window. The per-mirror deploy-key ruleset bypass (needed for the subtree force-push) has been restored.