### PR TITLE
Fix tier names in filtered content CTAs

### DIFF
--- a/packages/bulletin/partials/content-cta.hbs
+++ b/packages/bulletin/partials/content-cta.hbs
@@ -10,7 +10,7 @@
         <h4 class="gh-cta-title">{{t "This post is for subscribers only"}}</h4>
     {{/has}}
     {{#has visibility="filter"}}
-        <h4 class="gh-cta-title">{{t "This post is for subscribers on the {tiers} only" tiers=tiers}}</h4>
+        <h4 class="gh-cta-title">{{{t "This post is for subscribers on the {tiers} only" tiers=(tiers separator=", " lastSeparator=(t " and "))}}}</h4>
     {{/has}}
 
     <div class="gh-cta-actions">

--- a/packages/dawn/partials/content-cta.hbs
+++ b/packages/dawn/partials/content-cta.hbs
@@ -8,7 +8,7 @@
         <h2 class="single-cta-title">{{t "This post is for subscribers only"}}</h2>
     {{/has}}
     {{#has visibility="filter"}}
-        <h2 class="single-cta-title">{{t "This post is for subscribers on the {tiers} only" tiers=tiers}}</h2>
+        <h2 class="single-cta-title">{{{t "This post is for subscribers on the {tiers} only" tiers=(tiers separator=", " lastSeparator=(t " and "))}}}</h2>
     {{/has}}
     {{#if @member}}
         <button class="button single-cta-button" data-portal="account/plans">{{t "Upgrade now"}}</button>

--- a/packages/digest/partials/content-cta.hbs
+++ b/packages/digest/partials/content-cta.hbs
@@ -10,7 +10,7 @@
         <h4 class="gh-cta-title">{{t "This post is for subscribers only"}}</h4>
     {{/has}}
     {{#has visibility="filter"}}
-        <h4 class="gh-cta-title">{{t "This post is for subscribers on the {tiers} only" tiers=tiers}}</h4>
+        <h4 class="gh-cta-title">{{{t "This post is for subscribers on the {tiers} only" tiers=(tiers separator=", " lastSeparator=(t " and "))}}}</h4>
     {{/has}}
 
     <div class="gh-cta-actions">

--- a/packages/edition/partials/content-cta.hbs
+++ b/packages/edition/partials/content-cta.hbs
@@ -8,7 +8,7 @@
         <h2 class="single-cta-title">{{t "This post is for subscribers only"}}</h2>
     {{/has}}
     {{#has visibility="filter"}}
-        <h2 class="single-cta-title">{{t "This post is for subscribers on the {tiers} only" tiers=tiers}}</h2>
+        <h2 class="single-cta-title">{{{t "This post is for subscribers on the {tiers} only" tiers=(tiers separator=", " lastSeparator=(t " and "))}}}</h2>
     {{/has}}
     {{#if @member}}
         <button class="button single-cta-button" data-portal="account/plans">{{t "Upgrade now"}}</button>

--- a/packages/journal/partials/content-cta.hbs
+++ b/packages/journal/partials/content-cta.hbs
@@ -10,7 +10,7 @@
         <h4 class="gh-cta-title">{{t "This post is for subscribers only"}}</h4>
     {{/has}}
     {{#has visibility="filter"}}
-        <h4 class="gh-cta-title">{{t "This post is for subscribers on the {tiers} only" tiers=tiers}}</h4>
+        <h4 class="gh-cta-title">{{{t "This post is for subscribers on the {tiers} only" tiers=(tiers separator=", " lastSeparator=(t " and "))}}}</h4>
     {{/has}}
 
     <div class="gh-cta-actions">

--- a/packages/solo/partials/content-cta.hbs
+++ b/packages/solo/partials/content-cta.hbs
@@ -8,7 +8,7 @@
         <h4 class="gh-cta-title">{{t "This post is for subscribers only"}}</h4>
     {{/has}}
     {{#has visibility="filter"}}
-        <h4 class="gh-cta-title">{{t "This post is for subscribers on the {tiers} only" tiers=tiers}}</h4>
+        <h4 class="gh-cta-title">{{{t "This post is for subscribers on the {tiers} only" tiers=(tiers separator=", " lastSeparator=(t " and "))}}}</h4>
     {{/has}}
 
     <div class="gh-cta-actions">


### PR DESCRIPTION
Fixes https://linear.app/ghost/issue/BER-3789/

The theme-specific content CTA overrides passed tier objects directly to the translation helper, which rendered them as `[Object Object]`. Filtered paywalls now display a localized, human-readable list of tier names.

- Format filtered paywall tier names with the `tiers` helper in Bulletin, Dawn, Digest, Edition, Journal, and Solo.
- Use the translated final separator when joining multiple tier names.