### PR TITLE
Apply explicit pnpm security baseline to themes

### DIFF
--- a/packages/alto/pnpm-workspace.yaml
+++ b/packages/alto/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/packages/bulletin/pnpm-workspace.yaml
+++ b/packages/bulletin/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/packages/dawn/pnpm-workspace.yaml
+++ b/packages/dawn/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/packages/digest/pnpm-workspace.yaml
+++ b/packages/digest/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/packages/dope/pnpm-workspace.yaml
+++ b/packages/dope/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/packages/ease/pnpm-workspace.yaml
+++ b/packages/ease/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/packages/edge/pnpm-workspace.yaml
+++ b/packages/edge/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/packages/edition/pnpm-workspace.yaml
+++ b/packages/edition/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/packages/episode/pnpm-workspace.yaml
+++ b/packages/episode/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/packages/headline/pnpm-workspace.yaml
+++ b/packages/headline/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/packages/journal/pnpm-workspace.yaml
+++ b/packages/journal/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/packages/london/pnpm-workspace.yaml
+++ b/packages/london/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/packages/ruby/pnpm-workspace.yaml
+++ b/packages/ruby/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/packages/solo/pnpm-workspace.yaml
+++ b/packages/solo/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/packages/taste/pnpm-workspace.yaml
+++ b/packages/taste/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/packages/wave/pnpm-workspace.yaml
+++ b/packages/wave/pnpm-workspace.yaml
@@ -3,6 +3,10 @@
 # build script. When installing from the monorepo root, pnpm uses the root
 # pnpm-workspace.yaml instead (including its linkWorkspacePackages setting)
 # and ignores this file.
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to
   # build, test, or zip the theme.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 packages:
   - 'packages/*'
 


### PR DESCRIPTION
## What changed

- set `minimumReleaseAge: 4320` at the monorepo root
- explicitly enable `strictDepBuilds` and `blockExoticSubdeps` at the root
- propagate the same three settings to all 16 package-local `pnpm-workspace.yaml` files that are subtree-pushed into standalone theme repositories
- preserve the existing package-wide `dtrace-provider: false` denial everywhere

## Why

The root and standalone theme installs previously relied on pnpm defaults for package age, unreviewed lifecycle scripts, and exotic transitive dependency sources. The package-local workspace files are part of the subtree payload, so changing only the monorepo root would leave direct installs and Renovate PRs in standalone theme mirrors without the same policy.

There are no `true` build permissions in this repository, so this change grants no new lifecycle-script capability and has no version-scoped approvals to add.

## Impact

Both monorepo and standalone theme installs now:

- delay packages published within the last 72 hours
- fail on any unreviewed dependency build script
- reject exotic sources introduced through transitive dependencies

The next subtree sync will carry the package-local policy to each standalone mirror.

## Validation

- `pnpm@11.19.0 install --frozen-lockfile` — verified all 558 lockfile entries against supply-chain policies
- `pnpm build` — built all 16 themes
- `pnpm test` — all 16 themes passed Ghost 6.x compatibility checks
- `pnpm zip --theme taste`
- `npm test` in `packages/theme-translations` — 8 tests passed
- `npm pack --dry-run --ignore-scripts` for `@tryghost/shared-theme-assets` and `@tryghost/theme-translations`
- isolated `packages/taste` outside the monorepo with no lockfile or `node_modules`, then verified:
  - the package-local policy resolves to `4320`, `true`, and `true`
  - `pnpm install --no-frozen-lockfile`
  - `pnpm zip`
  - `pnpm exec gscan --fatal --verbose .`
- confirmed all 16 package-local policy files remain identical

Refs [PLA-321](https://linear.app/ghost/issue/PLA-321/make-the-72-hour-pnpm-cooldown-explicit-across-first-party-themes)
