### PR TITLE
Scoped theme publish permissions (PLA-329)

### DIFF
--- a/.github/workflows/shared-theme-assets.yml
+++ b/.github/workflows/shared-theme-assets.yml
@@ -12,8 +12,7 @@ on:
       - '.github/workflows/shared-theme-assets.yml'
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
   test:
@@ -65,6 +64,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/theme-translations.yml
+++ b/.github/workflows/theme-translations.yml
@@ -14,8 +14,7 @@ on:
       - '.github/workflows/theme-translations.yml'
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
   test:
@@ -35,6 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:


### PR DESCRIPTION
## Why

The shared-theme-assets and theme-translations workflows granted `contents: write` and `id-token: write` at workflow scope. Every job inherited those permissions, including tests, dependency installation, and the shared-assets pull-request dry run.

PLA-329 limits publish credentials to the jobs that actually publish.

## What changed

- defaults both npm workflows to `contents: read`
- grants `contents: write` and `id-token: write` only to:
  - `shared-theme-assets / publish`
  - `theme-translations / publish`
- leaves tests and the shared-assets dry run read-only
- does not change pnpm policy or other PLA-321 configuration

The publish jobs retain the permissions needed for npm provenance and their existing tag/version commits. No workflow uses `packages: write`.

## Permission audit

Audited all 34 root and embedded theme workflows. The only effective write grants are the two publish jobs above. Every dependency-installing test/build job has no `id-token: write`, `contents: write`, or `packages: write`.

## Validation

- permission assertions across all 34 workflows
- `actionlint` on all embedded theme workflows
- root `actionlint -ignore SC2015` (the two excluded SC2015 diagnostics already exist on `main` in unchanged translation publish shell logic)
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm test:ci --theme taste`
- `corepack pnpm build`
- `npm test --prefix packages/theme-translations`
- `npm publish --provenance --dry-run` for both npm packages
- `git diff --check`